### PR TITLE
Fixing SenderEmailAddress for exchange messages

### DIFF
--- a/outlook_analyzer.py
+++ b/outlook_analyzer.py
@@ -101,8 +101,17 @@ def extract_outlook_information(max_email_number_to_extract_input,date_start_inp
         #check and store unread email info
         try:
             if (item.Unread == True):
-                sender = item.SenderEmailAddress
+
+                if item.Class == 43:
+                    if item.SenderEmailType == "EX":
+                        sender = item.Sender.GetExchangeUser().PrimarySmtpAddress
+                    else:
+                        sender = item.SenderEmailAddress
+                else:
+                    sender = item.SenderEmailAddress
+    
                 unread_senders_raw_list.append(sender)
+
         except Exception as e:
             append_to_error_list(str(sys._getframe().f_code.co_name),str(e))
         


### PR DESCRIPTION
Exchange messages do not show the correct email address
fixing this with the long exchange info and replacing with the actual SMTP email address. 
![20220415-225502_sender_plot](https://user-images.githubusercontent.com/101381606/163660662-2e80e11e-2c71-4547-8a5f-e6a0c7cc8b81.jpg)

