### PR TITLE
Update outlook_analyzer.py

### DIFF
--- a/outlook_analyzer.py
+++ b/outlook_analyzer.py
@@ -314,7 +314,10 @@ def return_sender(outlook_object):
         else:
             sender = outlook_object.SenderEmailAddress
     elif outlook_object.Class == 56 or outlook_object.Class == 53: #Class "53" and "56" are responses to meeting invites
+        if outlook_object.SenderEmailType == "EX": # SenderEmailType "EX" is assigned to MailItems received from internal MS Exchange
             sender = outlook_object.SenderName
+        else:
+            sender = "Unavailable"
     else:
         sender = outlook_object.SenderEmailAddress
 

--- a/outlook_analyzer.py
+++ b/outlook_analyzer.py
@@ -313,6 +313,8 @@ def return_sender(outlook_object):
             sender = outlook_object.Sender.GetExchangeUser().PrimarySmtpAddress
         else:
             sender = outlook_object.SenderEmailAddress
+    elif outlook_object.Class == 56 or outlook_object.Class == 53: #Class "53" and "56" are responses to meeting invites
+            sender = outlook_object.SenderName
     else:
         sender = outlook_object.SenderEmailAddress
 


### PR DESCRIPTION
Fix for the long exchange text for sender email address for meeting responses - since there is no email attribute using the sender name